### PR TITLE
Ocean::Util::JID::to_jid bug fix

### DIFF
--- a/lib/Ocean/Util/JID.pm
+++ b/lib/Ocean/Util/JID.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use base 'Exporter';
 use Ocean::JID;
+use Scalar::Util qw(blessed);
 
 our %EXPORT_TAGS = (all => [qw(
     to_jid
@@ -16,7 +17,7 @@ sub to_jid {
     my ($address) = @_;
     return (!$address)
         ? ""
-        : $address->isa("Ocean::JID") 
+        : blessed($address) && $address->isa("Ocean::JID")
             ? $address
             : Ocean::JID->new($address);
 }

--- a/t/01_core/util_jid.t
+++ b/t/01_core/util_jid.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+use Test::Exception;
+
+use Ocean::Util::JID qw(
+    to_jid
+);
+
+lives_ok {
+    my $jid = to_jid('kusanagi@example.org/resource');
+    isa_ok $jid, 'Ocean::JID';
+};
+
+lives_ok {
+    my $jid2 = to_jid('2ndgig@example.org/resource');
+    isa_ok $jid2, 'Ocean::JID';
+};


### PR DESCRIPTION
先日話していた数値から始まるJIDの場合の問題の修正です

数値にたいしてisaを呼び出すと，'Can't call method "isa" without a package or object reference'といわれて落ちるようです．blessされているか確認してからisaするようにしました．
