### PR TITLE
Write all remaining buffer before closing socket

### DIFF
--- a/lib/Ocean/StreamComponent/IO/Socket/AEHandleAdapter.pm
+++ b/lib/Ocean/StreamComponent/IO/Socket/AEHandleAdapter.pm
@@ -43,7 +43,7 @@ sub release {
 sub shutdown {
     my $self = shift;
     if ($self->{_handle}) {
-        CORE::shutdown($self->{_handle}->fh, 1);
+        $self->{_handle}->push_shutdown();
         $self->{_handle}->destroy();
         delete $self->{_handle};
     }
@@ -102,11 +102,9 @@ sub _initialize_handle {
 
 sub close {
     my $self = shift;
-    #$self->{_handle}->on_drain(sub {
-        debugf('<Stream> <Socket> @shutdown');
-        $self->shutdown();
-        $self->{_delegate}->on_socket_closed();
-    #});
+    debugf('<Stream> <Socket> @shutdown');
+    $self->shutdown();
+    $self->{_delegate}->on_socket_closed();
 }
 
 sub accept_tls {


### PR DESCRIPTION
I had a problem that the buffer was not completely flushed before closing the socket when implementing stateless protocols on Ocean.

I fixed it by using AnyEvent's push_shutdown but I also seen "on_drain" callback (which does pretty much everything that push_shutdown does) being commented-out. I'm curious if there was any specific reason to not use push_shutdown/on_drain and closing the socket directly.

--- commit message
- Socket was being closed before the remaining buffer was flushed.
- For xmpp sockets this wouldn't be a problem as the server rarely closes a connection.
- But it would close the connection before sending all the response for stateless protocols (ie. HTTP).
